### PR TITLE
Locker expanded with custom user defaults

### DIFF
--- a/Example/TouchID/ViewController.swift
+++ b/Example/TouchID/ViewController.swift
@@ -18,6 +18,7 @@ public final class ViewController: UIViewController {
     // MARK: - Private properties -
 
     private let identifier = "TouchIDSampleApp"
+
 }
 
 // MARK: - Locker usage -
@@ -57,6 +58,15 @@ extension ViewController {
 
     var configuredBiometricsAuthentication: BiometricsType {
         return Locker.configuredBiometricsAuthentication
+    }
+}
+
+// MARK: User defaults
+
+extension ViewController {
+
+    func setUserDefaults() {
+        Locker.userDefaults = UserDefaults(suiteName: "customDomain")
     }
 }
 

--- a/Example/TouchID/ViewController.swift
+++ b/Example/TouchID/ViewController.swift
@@ -65,8 +65,12 @@ extension ViewController {
 
 extension ViewController {
 
-    func setUserDefaults() {
+    func setCustomUserDefaults() {
         Locker.userDefaults = UserDefaults(suiteName: "customDomain")
+    }
+
+    func resetUserDefaults() {
+        Locker.userDefaults = nil
     }
 }
 

--- a/Example/TouchIDTests/TouchIDTests.swift
+++ b/Example/TouchIDTests/TouchIDTests.swift
@@ -17,6 +17,7 @@ class TouchIDTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
         containerViewController = ViewController()
+        containerViewController.setUserDefaults()
     }
 
     // MARK: - Store Retrieve and Delete -

--- a/Example/TouchIDTests/TouchIDTests.swift
+++ b/Example/TouchIDTests/TouchIDTests.swift
@@ -17,11 +17,37 @@ class TouchIDTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
         containerViewController = ViewController()
-        containerViewController.setUserDefaults()
+    }
+
+    override func tearDown() {
+        containerViewController.resetUserDefaults()
+        super.tearDown()
     }
 
     // MARK: - Store Retrieve and Delete -
     func testStoreAndRetrieveSecret() {
+
+        // Store
+        containerViewController.storeSecret()
+
+        // Retrieve
+        let asyncExpectation = expectation(description: "Async block executed")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            self.containerViewController.readSecret(success: { (secret) in
+                XCTAssertEqual(secret, self.containerViewController.topSecret)
+                asyncExpectation.fulfill()
+            }, failure: { _ in
+                XCTFail("Error while retrieve the secret")
+                asyncExpectation.fulfill()
+            })
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testStoreAndRetrieveSecretWithCustomUserDefaults() {
+
+        containerViewController.setCustomUserDefaults()
 
         // Store
         containerViewController.storeSecret()
@@ -91,12 +117,30 @@ class TouchIDTests: XCTestCase {
         XCTAssertTrue(containerViewController.shouldUseAuthWithBiometrics)
     }
 
+    func testShouldUseAuthFlagWithCustomUserDefaults() {
+        containerViewController.setCustomUserDefaults()
+        containerViewController.shouldUseAuthWithBiometrics = true
+        XCTAssertTrue(containerViewController.shouldUseAuthWithBiometrics)
+    }
+
     func testDidAskToUseAuthWithBiometrics() {
         containerViewController.didAskToUseAuthWithBiometrics = true
         XCTAssertTrue(containerViewController.didAskToUseAuthWithBiometrics)
     }
 
+    func testDidAskToUseAuthWithBiometricsWithCustomUserDefaults() {
+        containerViewController.setCustomUserDefaults()
+        containerViewController.didAskToUseAuthWithBiometrics = true
+        XCTAssertTrue(containerViewController.didAskToUseAuthWithBiometrics)
+    }
+
     func testShouldAddSecretToKeychainOnNextLogin() {
+        containerViewController.shouldAddSecretToKeychainOnNextLogin = true
+        XCTAssertTrue(containerViewController.shouldAddSecretToKeychainOnNextLogin)
+    }
+
+    func testShouldAddSecretToKeychainOnNextLoginWithCustomUserDefaults() {
+        containerViewController.setCustomUserDefaults()
         containerViewController.shouldAddSecretToKeychainOnNextLogin = true
         XCTAssertTrue(containerViewController.shouldAddSecretToKeychainOnNextLogin)
     }

--- a/Locker.podspec
+++ b/Locker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Locker"
-  s.version      = "2.1.0"
+  s.version      = "2.2.0"
   s.summary      = "Securely lock your secrets under the watch of TouchID or FaceID keeper 🔒"
   s.description  = <<-DESC
                   Lightweight manager for saving, fetching and updating secrets (string value) in Keychain using Biometric Authentication. 

--- a/Locker/Locker/Locker.h
+++ b/Locker/Locker/Locker.h
@@ -15,6 +15,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Properties
 
+
+/**
+ User defaults used for storing shouldUseAuthenticationWithBiometrics, askToUseAuthenticationWithBiometrics and shouldAddPasscodeToKeychainOnNextLogin values
+
+ Should be set once before using any other Locker methods.
+ If not set, standard user defaults will be used.
+ */
+@property (nonatomic, strong, class, nullable) NSUserDefaults *userDefaults;
+
 /**
  Boolean value that indicates if biometric settings have changed
  */
@@ -74,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Additional helpers
 
 /**
-  Used for fetching whether user enabled authentication with biometrics.
+ Used for fetching whether user enabled authentication with biometrics.
 
  @param uniqueIdentifier used for fetching shouldUseAuthenticationWithBiometrics value
  @return used to determine whether user enabled authentication with biometrics

--- a/Locker/Locker/Locker.m
+++ b/Locker/Locker/Locker.m
@@ -18,7 +18,7 @@ static NSUserDefaults *currentUserDefaults;
 + (void)setSecret:(NSString *)secret forUniqueIdentifier:(NSString *)uniqueIdentifier
 {
     #if TARGET_OS_SIMULATOR
-    [currentUserDefaults setObject:secret forKey:uniqueIdentifier];
+    [Locker.userDefaults setObject:secret forKey:uniqueIdentifier];
     #else
     NSDictionary *query = @{
                             (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
@@ -63,7 +63,7 @@ static NSUserDefaults *currentUserDefaults;
 + (void)retrieveCurrentSecretForUniqueIdentifier:(NSString *)uniqueIdentifier operationPrompt:(NSString *)operationPrompt success:(void(^)(NSString * _Nullable secret))success failure:(void(^)(OSStatus failureStatus))failure
 {
     #if TARGET_OS_SIMULATOR
-    NSString *simulatorSecret = [currentUserDefaults stringForKey:uniqueIdentifier];
+    NSString *simulatorSecret = [Locker.userDefaults stringForKey:uniqueIdentifier];
     if (!simulatorSecret) {
         failure(errSecItemNotFound);
         return;
@@ -107,7 +107,7 @@ static NSUserDefaults *currentUserDefaults;
 {
 
     #if TARGET_OS_SIMULATOR
-    [currentUserDefaults removeObjectForKey:uniqueIdentifier];
+    [Locker.userDefaults removeObjectForKey:uniqueIdentifier];
     #else
     NSDictionary *query = @{
                             (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
@@ -125,7 +125,7 @@ static NSUserDefaults *currentUserDefaults;
 
 + (BOOL)shouldUseAuthenticationWithBiometricsForUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    return [currentUserDefaults boolForKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
+    return [Locker.userDefaults boolForKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
 }
 
 + (void)setShouldUseAuthenticationWithBiometrics:(BOOL)shouldUseAuthenticationWithBiometrics forUniqueIdentifier:(NSString *)uniqueIdentifier
@@ -134,36 +134,36 @@ static NSUserDefaults *currentUserDefaults;
         [Locker setShouldAddSecretToKeychainOnNextLogin:NO forUniqueIdentifier:uniqueIdentifier];
     }
     
-    [currentUserDefaults setBool:shouldUseAuthenticationWithBiometrics forKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults setBool:shouldUseAuthenticationWithBiometrics forKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
 }
 
 + (BOOL)didAskToUseAuthenticationWithBiometricsForUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    return [currentUserDefaults boolForKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
+    return [Locker.userDefaults boolForKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
 }
 
 + (void)setDidAskToUseAuthenticationWithBiometrics:(BOOL)askToUseAuthenticationWithBiometrics forUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    [currentUserDefaults setBool:askToUseAuthenticationWithBiometrics forKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults setBool:askToUseAuthenticationWithBiometrics forKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
 }
 
 + (BOOL)shouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    return [currentUserDefaults boolForKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
+    return [Locker.userDefaults boolForKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
 }
 
 + (void)setShouldAddSecretToKeychainOnNextLogin:(BOOL)shouldAddSecretToKeychainOnNextLogin forUniqueIdentifier:(NSString *)uniqueIdentifier
 {
-    [currentUserDefaults setBool:shouldAddSecretToKeychainOnNextLogin forKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults setBool:shouldAddSecretToKeychainOnNextLogin forKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
 }
 
 #pragma mark - Data reset
 
 + (void)resetForUniqueIdentifier:(NSString *)uniqueIdentifier;
 {
-    [currentUserDefaults removeObjectForKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
-    [currentUserDefaults removeObjectForKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
-    [currentUserDefaults removeObjectForKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults removeObjectForKey:[LockerHelpers keyDidAskToUseBiometricsIDForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults removeObjectForKey:[LockerHelpers keyShouldAddSecretToKeychainOnNextLoginForUniqueIdentifier:uniqueIdentifier]];
+    [Locker.userDefaults removeObjectForKey:[LockerHelpers keyBiometricsIDActivatedForUniqueIdentifier:uniqueIdentifier]];
     [Locker deleteSecretForUniqueIdentifier:uniqueIdentifier];
 }
 
@@ -195,6 +195,9 @@ static NSUserDefaults *currentUserDefaults;
 
 + (NSUserDefaults *)userDefaults
 {
+    if (currentUserDefaults == nil) {
+        return [NSUserDefaults standardUserDefaults];
+    }
     return currentUserDefaults;
 }
 


### PR DESCRIPTION
Instead of standard user defaults user can now set custom user defaults for storing shouldUseAuthenticationWithBiometrics, askToUseAuthenticationWithBiometrics and shouldAddPasscodeToKeychainOnNextLogin values