### PR TITLE
Use targetEnvironment method for isSimulator check

### DIFF
--- a/Sources/Locker/Helpers/LockerHelpers.swift
+++ b/Sources/Locker/Helpers/LockerHelpers.swift
@@ -62,7 +62,11 @@ class LockerHelpers {
     }
 
     static var isSimulator: Bool {
-        LockerHelpers.deviceCode == "x86_64"
+        #if targetEnvironment(simulator)
+            return true
+        #else
+            return false
+        #endif
     }
 
     // MARK: - Private properties


### PR DESCRIPTION
So, other PRs are failing on Bitrise because one of the tests is failing and the reason for that is that `isSimulator` property returns a wrong value. 
Implementation of this property was outdated. It relied on `arm64` processor architecture not being supported on Xcode Simulators, which is no longer the case. Instead, I used `targetEnvironment(simulator)` method and now all the tests are running again.