### PR TITLE
Exclude Tests folder from Locker target and add separate test target

### DIFF
--- a/Example/Pods/Local Podspecs/Locker.podspec.json
+++ b/Example/Pods/Local Podspecs/Locker.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Locker",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "summary": "Securely lock your secrets under the watch of TouchID or FaceID keeper 🔒",
   "description": "Lightweight manager for saving, fetching and updating secrets (string value) in Keychain using Biometric Authentication. \nIncludes methods for checking general changes in Biometric settings and device biometric type info (FaceID / TouchID / None).",
   "homepage": "https://github.com/infinum/Locker.git",
@@ -16,7 +16,7 @@
   "swift_versions": "5.6",
   "source": {
     "git": "https://github.com/infinum/Locker.git",
-    "tag": "3.0.5"
+    "tag": "3.0.6"
   },
   "source_files": "Sources/Locker/**/*.swift",
   "exclude_files": "Sources/Locker/Tests/",

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Locker (3.0.6)
-  - Locker/Tests (3.0.6)
+  - Locker (3.0.5)
+  - Locker/Tests (3.0.5)
 
 DEPENDENCIES:
   - Locker (from `../Locker.podspec`)

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Locker (3.0.5)
-  - Locker/Tests (3.0.5)
+  - Locker (3.0.6)
+  - Locker/Tests (3.0.6)
 
 DEPENDENCIES:
   - Locker (from `../Locker.podspec`)

--- a/Example/Pods/Target Support Files/Locker/Locker-Info.plist
+++ b/Example/Pods/Target Support Files/Locker/Locker-Info.plist
@@ -2,25 +2,25 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>${PODS_DEVELOPMENT_LANGUAGE}</string>
-  <key>CFBundleExecutable</key>
-  <string>${EXECUTABLE_NAME}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>FMWK</string>
-  <key>CFBundleShortVersionString</key>
-  <string>3.0.5</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>${CURRENT_PROJECT_VERSION}</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>${PODS_DEVELOPMENT_LANGUAGE}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.0.6</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${CURRENT_PROJECT_VERSION}</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Example/Pods/Target Support Files/Locker/ResourceBundle-Locker_Locker-Locker-Info.plist
+++ b/Example/Pods/Target Support Files/Locker/ResourceBundle-Locker_Locker-Locker-Info.plist
@@ -2,23 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>${PODS_DEVELOPMENT_LANGUAGE}</string>
-  <key>CFBundleIdentifier</key>
-  <string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
-  <key>CFBundleInfoDictionaryVersion</key>
-  <string>6.0</string>
-  <key>CFBundleName</key>
-  <string>${PRODUCT_NAME}</string>
-  <key>CFBundlePackageType</key>
-  <string>BNDL</string>
-  <key>CFBundleShortVersionString</key>
-  <string>3.0.5</string>
-  <key>CFBundleSignature</key>
-  <string>????</string>
-  <key>CFBundleVersion</key>
-  <string>1</string>
-  <key>NSPrincipalClass</key>
-  <string></string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>${PODS_DEVELOPMENT_LANGUAGE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${PRODUCT_BUNDLE_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.0.6</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/Locker.podspec
+++ b/Locker.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Locker"
-  s.version      = "3.0.5"
+  s.version      = "3.0.6"
   s.summary      = "Securely lock your secrets under the watch of TouchID or FaceID keeper 🔒"
   s.description  = <<-DESC
                   Lightweight manager for saving, fetching and updating secrets (string value) in Keychain using Biometric Authentication. 

--- a/Package.swift
+++ b/Package.swift
@@ -6,13 +6,14 @@ import PackageDescription
 let package = Package(
     name: "Locker",
     platforms: [
-            .iOS(.v10)
+        .iOS(.v10)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Locker",
-            targets: ["Locker"])
+            targets: ["Locker"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -23,10 +24,17 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Locker",
+            path: "Sources/Locker",
+            exclude: ["Tests"], // exclude test sources so Locker module doesn't depend on XCTest
             resources: [
                 .process("Helpers/BiometryAvailabilityDeviceList.json"),
                 .copy("SupportingFiles/PrivacyInfo.xcprivacy")
-                ]
+            ]
+        ),
+        .testTarget(
+            name: "LockerTests",
+            dependencies: ["Locker"],
+            path: "Sources/Locker/Tests" // use the existing test folder inside Locker
         )
     ]
 )


### PR DESCRIPTION
### Summary
This PR fixes a build issue where the `Locker` runtime module was compiled with a dependency on `XCTest`.  
That caused consuming projects (e.g. apps importing Locker) to fail to build with errors like:


### Changes
- Updated `Package.swift`:
  - Excluded the `Tests` subfolder from the main `Locker` target.
  - Added a dedicated `.testTarget` pointing to `Sources/Locker/Tests`.
- This prevents `XCTest` symbols from leaking into the runtime `Locker` module.
- No functional changes to Locker’s runtime code.

### Result
Locker can now be used as a Swift Package dependency in iOS apps without requiring testing search paths or linking XCTest.  
Build and archive now succeed on both Simulator and device targets.

### Testing
- Verified that `Locker.swiftmodule` no longer references XCTest.
- Confirmed successful build and run in an iOS project using SPM integration.
