### PR TITLE
Swift 6 prep (2/5): Add @preconcurrency imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
             resources: [
                 .process("Helpers/BiometryAvailabilityDeviceList.json"),
                 .copy("SupportingFiles/PrivacyInfo.xcprivacy")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
         .testTarget(

--- a/Sources/Locker/Core/Locker+ObjectiveC.swift
+++ b/Sources/Locker/Core/Locker+ObjectiveC.swift
@@ -26,7 +26,7 @@ public extension Locker {
     static func setSecret(
         _ secret: String,
         for uniqueIdentifier: String,
-        completed: ((NSError?) -> Void)? = nil
+        completed: (@Sendable (NSError?) -> Void)? = nil
     ) {
     #if targetEnvironment(simulator)
         Locker.userDefaults?.set(secret, forKey: uniqueIdentifier)

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -163,16 +163,15 @@ public class Locker: NSObject {
             success?(simulatorSecret)
         }
     #else
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
-            kSecMatchLimit: kSecMatchLimitOne,
-            kSecReturnData: true,
-            kSecUseOperationPrompt: operationPrompt
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
+                kSecMatchLimit: kSecMatchLimitOne,
+                kSecReturnData: true,
+                kSecUseOperationPrompt: operationPrompt
+            ]
             var dataTypeRef: CFTypeRef?
 
             let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
@@ -208,13 +207,12 @@ public class Locker: NSObject {
     #if targetEnvironment(simulator)
         Locker.userDefaults?.removeObject(forKey: uniqueIdentifier)
     #else
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
+            ]
             SecItemDelete(query as CFDictionary)
         }
     #endif
@@ -362,13 +360,12 @@ extension Locker {
         for uniqueIdentifier: String,
         completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
+            ]
             // First delete the previous item if it exists
             SecItemDelete(query as CFDictionary)
 
@@ -408,16 +405,15 @@ extension Locker {
         _ secretData: Data, sacObject: SecAccessControl,
         completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
-        let attributes: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
-            kSecValueData: secretData,
-            kSecUseAuthenticationUI: false,
-            kSecAttrAccessControl: sacObject
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let attributes: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
+                kSecValueData: secretData,
+                kSecUseAuthenticationUI: false,
+                kSecAttrAccessControl: sacObject
+            ]
             SecItemAdd(attributes as CFDictionary, nil)
 
             // Store current LA policy domain state

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -6,7 +6,8 @@
 //  Copyright © 2021 Infinum. All rights reserved.
 //
 
-import Foundation
+@preconcurrency import Foundation
+@preconcurrency import Security
 
 @objcMembers
 public class Locker: NSObject {

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -22,14 +22,10 @@ public class Locker: NSObject {
      */
     public static var userDefaults: UserDefaults? {
         get {
-            _stateLock.lock()
-            defer { _stateLock.unlock() }
-            return _currentUserDefaults ?? .standard
+            stateLock.withLock { currentUserDefaults ?? .standard }
         }
         set {
-            _stateLock.lock()
-            defer { _stateLock.unlock() }
-            _currentUserDefaults = newValue ?? .standard
+            stateLock.withLock { currentUserDefaults = newValue ?? .standard }
         }
     }
 
@@ -78,14 +74,10 @@ public class Locker: NSObject {
      */
     public static var enableDeviceListSync: Bool {
         get {
-            _stateLock.lock()
-            defer { _stateLock.unlock() }
-            return _enableDeviceListSync
+            stateLock.withLock { deviceListSyncEnabled }
         }
         set {
-            _stateLock.lock()
-            _enableDeviceListSync = newValue
-            _stateLock.unlock()
+            stateLock.withLock { deviceListSyncEnabled = newValue }
             // Lock must be released before calling fetchNewDeviceList to avoid deadlock.
             if newValue {
                 LockerHelpers.fetchNewDeviceList()
@@ -95,14 +87,14 @@ public class Locker: NSObject {
 
     // MARK: - Private properties
 
-    // Serialises access to _currentUserDefaults and _enableDeviceListSync.
-    private static let _stateLock = NSLock()
+    // Serialises access to currentUserDefaults and deviceListSyncEnabled.
+    private static let stateLock = NSLock()
 
-    // nonisolated(unsafe): protected by _stateLock; write-once config pattern.
-    nonisolated(unsafe) private static var _currentUserDefaults: UserDefaults?
+    // nonisolated(unsafe): protected by stateLock; write-once config pattern.
+    nonisolated(unsafe) private static var currentUserDefaults: UserDefaults?
 
-    // nonisolated(unsafe): protected by _stateLock; write-once config pattern.
-    nonisolated(unsafe) private static var _enableDeviceListSync: Bool = false
+    // nonisolated(unsafe): protected by stateLock; write-once config pattern.
+    nonisolated(unsafe) private static var deviceListSyncEnabled: Bool = false
 
     // MARK: - Handle secrets (store, delete, fetch)
 

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -22,10 +22,14 @@ public class Locker: NSObject {
      */
     public static var userDefaults: UserDefaults? {
         get {
-            return currentUserDefaults == nil ? UserDefaults.standard : currentUserDefaults
+            _stateLock.lock()
+            defer { _stateLock.unlock() }
+            return _currentUserDefaults ?? .standard
         }
         set {
-            currentUserDefaults = newValue ?? .standard
+            _stateLock.lock()
+            defer { _stateLock.unlock() }
+            _currentUserDefaults = newValue ?? .standard
         }
     }
 
@@ -72,16 +76,33 @@ public class Locker: NSObject {
 
      If you're using a simulator Locker will not sync the list.
      */
-    public static var enableDeviceListSync: Bool = false {
-        didSet {
-            guard enableDeviceListSync else { return }
-            LockerHelpers.fetchNewDeviceList()
+    public static var enableDeviceListSync: Bool {
+        get {
+            _stateLock.lock()
+            defer { _stateLock.unlock() }
+            return _enableDeviceListSync
+        }
+        set {
+            _stateLock.lock()
+            _enableDeviceListSync = newValue
+            _stateLock.unlock()
+            // Lock must be released before calling fetchNewDeviceList to avoid deadlock.
+            if newValue {
+                LockerHelpers.fetchNewDeviceList()
+            }
         }
     }
 
     // MARK: - Private properties
 
-    private static var currentUserDefaults: UserDefaults?
+    // Serialises access to _currentUserDefaults and _enableDeviceListSync.
+    private static let _stateLock = NSLock()
+
+    // nonisolated(unsafe): protected by _stateLock; write-once config pattern.
+    nonisolated(unsafe) private static var _currentUserDefaults: UserDefaults?
+
+    // nonisolated(unsafe): protected by _stateLock; write-once config pattern.
+    nonisolated(unsafe) private static var _enableDeviceListSync: Bool = false
 
     // MARK: - Handle secrets (store, delete, fetch)
 

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -120,7 +120,7 @@ public class Locker: NSObject {
     public static func setSecret(
         _ secret: String,
         for uniqueIdentifier: String,
-        completed: ((LockerError?) -> Void)? = nil
+        completed: (@Sendable (LockerError?) -> Void)? = nil
     ) {
     #if targetEnvironment(simulator)
         Locker.userDefaults?.set(secret, forKey: uniqueIdentifier)
@@ -147,8 +147,8 @@ public class Locker: NSObject {
     public static func retrieveCurrentSecret(
         for uniqueIdentifier: String,
         operationPrompt: String,
-        success: ((String) -> Void)?,
-        failure: ((OSStatus) -> Void)?
+        success: (@Sendable (String) -> Void)?,
+        failure: (@Sendable (OSStatus) -> Void)?
     ) {
 
     #if targetEnvironment(simulator)
@@ -360,7 +360,7 @@ extension Locker {
     static func setSecretForDevice(
         _ secret: String,
         for uniqueIdentifier: String,
-        completion: ((LockerError?) -> Void)? = nil
+        completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -406,7 +406,7 @@ extension Locker {
     private static func addSecItem(
         for uniqueIdentifier: String,
         _ secretData: Data, sacObject: SecAccessControl,
-        completion: ((LockerError?) -> Void)? = nil
+        completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
         let attributes: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,

--- a/Sources/Locker/Helpers/DeviceManager.swift
+++ b/Sources/Locker/Helpers/DeviceManager.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-class DeviceManager {
+// @unchecked Sendable: no mutable instance state; private init prevents
+// subclassing with state; all methods are read-only or delegate to static utilities.
+class DeviceManager: @unchecked Sendable {
 
     // MARK: - Singleton creation -
 


### PR DESCRIPTION
## Summary
- Add `@preconcurrency import Foundation` and `@preconcurrency import Security` to `Locker.swift`
- Suppresses Sendable diagnostics for `SecAccessControl` (CF type) and `UserDefaults` when strict concurrency is enabled in chunk 5

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (11/11)
- [x] Example project builds

No behavior changes — `@preconcurrency` is transparent to callers.