### PR TITLE
Swift 6 prep (5/5): Enable StrictConcurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
             resources: [
                 .process("Helpers/BiometryAvailabilityDeviceList.json"),
                 .copy("SupportingFiles/PrivacyInfo.xcprivacy")
+            ],
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency")
             ]
         ),
         .testTarget(

--- a/Sources/Locker/Core/Locker.swift
+++ b/Sources/Locker/Core/Locker.swift
@@ -163,16 +163,15 @@ public class Locker: NSObject {
             success?(simulatorSecret)
         }
     #else
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
-            kSecMatchLimit: kSecMatchLimitOne,
-            kSecReturnData: true,
-            kSecUseOperationPrompt: operationPrompt
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
+                kSecMatchLimit: kSecMatchLimitOne,
+                kSecReturnData: true,
+                kSecUseOperationPrompt: operationPrompt
+            ]
             var dataTypeRef: CFTypeRef?
 
             let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
@@ -208,13 +207,12 @@ public class Locker: NSObject {
     #if targetEnvironment(simulator)
         Locker.userDefaults?.removeObject(forKey: uniqueIdentifier)
     #else
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
+            ]
             SecItemDelete(query as CFDictionary)
         }
     #endif
@@ -362,13 +360,12 @@ extension Locker {
         for uniqueIdentifier: String,
         completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
-        let query: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier)
+            ]
             // First delete the previous item if it exists
             SecItemDelete(query as CFDictionary)
 
@@ -408,16 +405,15 @@ extension Locker {
         _ secretData: Data, sacObject: SecAccessControl,
         completion: (@Sendable (LockerError?) -> Void)? = nil
     ) {
-        let attributes: [CFString: Any] = [
-            kSecClass: kSecClassGenericPassword,
-            kSecAttrService: LockerHelpers.keyKeychainServiceName,
-            kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
-            kSecValueData: secretData,
-            kSecUseAuthenticationUI: false,
-            kSecAttrAccessControl: sacObject
-        ]
-
         DispatchQueue.global(qos: .default).async {
+            let attributes: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: LockerHelpers.keyKeychainServiceName,
+                kSecAttrAccount: LockerHelpers.keyKeychainAccountNameForUniqueIdentifier(uniqueIdentifier),
+                kSecValueData: secretData,
+                kSecUseAuthenticationUI: false,
+                kSecAttrAccessControl: sacObject
+            ]
             SecItemAdd(attributes as CFDictionary, nil)
 
             // Store current LA policy domain state


### PR DESCRIPTION
## Summary
- Add `.enableUpcomingFeature("StrictConcurrency")` to the `Locker` target in `Package.swift` — surfaces full data-race diagnostics under Swift 5.10 without requiring `swiftLanguageMode(.v6)` (which needs tools 6.0 and would break Xcode 15 consumers)
- Fix the four resulting warnings: `[CFString: Any]` dictionaries were captured across `@Sendable` async closures. Each dictionary is now constructed *inside* its closure so only `Sendable` `String` values are captured across the boundary:
  - `retrieveCurrentSecret` query dict
  - `deleteSecret` query dict
  - `setSecretForDevice` query dict
  - `addSecItem` attributes dict

## Result
Build produces **zero warnings** under strict concurrency. Library is fully Swift 6-ready while remaining backward compatible for non-Swift-6 consumers.

## Test plan
- [x] `swift build` — zero warnings
- [x] `swift test` — 11/11 pass